### PR TITLE
Bugfix NULL twitch streams

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.6.35.1'
+def runeLiteVersion = '1.6.36.1'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
@@ -26,7 +26,7 @@ dependencies {
 }
 
 group = 'osrsstreamers'
-version = '1.4.1'
+version = '1.4.2'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/com/osrsstreamers/OsrsStreamersPlugin.java
+++ b/src/main/java/com/osrsstreamers/OsrsStreamersPlugin.java
@@ -122,6 +122,7 @@ public class OsrsStreamersPlugin extends Plugin
 			streamerHandler = new StreamerHandler(client, config);
 			checkTokenValidity();
 			eventBus.register(streamerHandler);
+			eventBus.register(streamerHandler);
 			this.streamingPlayerOverlay.streamerHandler = streamerHandler;
 			this.streamingPlayerMinimapOverlay.streamerHandler = streamerHandler;
 			overlayManager.add(streamingPlayerOverlay);

--- a/src/main/java/com/osrsstreamers/OsrsStreamersPlugin.java
+++ b/src/main/java/com/osrsstreamers/OsrsStreamersPlugin.java
@@ -122,7 +122,6 @@ public class OsrsStreamersPlugin extends Plugin
 			streamerHandler = new StreamerHandler(client, config);
 			checkTokenValidity();
 			eventBus.register(streamerHandler);
-			eventBus.register(streamerHandler);
 			this.streamingPlayerOverlay.streamerHandler = streamerHandler;
 			this.streamingPlayerMinimapOverlay.streamerHandler = streamerHandler;
 			overlayManager.add(streamingPlayerOverlay);

--- a/src/main/java/com/osrsstreamers/handler/StreamerHandler.java
+++ b/src/main/java/com/osrsstreamers/handler/StreamerHandler.java
@@ -124,7 +124,7 @@ public class StreamerHandler {
     @Subscribe
     public void onPlayerMenuOptionClicked(PlayerMenuOptionClicked event) {
         if (event.getMenuOption().contains(WATCH_STREAM_ACTION)) {
-            openTwitchStream(Text.removeTags(event.getMenuTarget()));
+            openTwitchStream(Text.removeTags(event.getMenuTarget()).trim().replace('\u00A0', ' '));
         }
     }
 


### PR DESCRIPTION
Replacing NBSP from the MenuEntry clicked event for a space to prevent NULL's when fetching Twitch URL from characters with a space in their name.